### PR TITLE
Added Makefile and freeVM()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *~
-mas
+markandsweep

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+BIN=markandsweep
+
 .PHONY : clean 
 
-mas : main.c
-	gcc  -ggdb -std=gnu99  main.c -o mas
+$(BIN) : main.c
+	$(CC)  -ggdb -std=gnu99  main.c -o $(BIN)
 
 clean :
-	rm -f mas *~
+	rm -f $(BIN) *~
 
-run : mas
-	valgrind  --leak-check=yes mas
+run : $(BIN)
+	valgrind  --leak-check=yes $(BIN)
 

--- a/main.c
+++ b/main.c
@@ -168,8 +168,8 @@ void objectPrint(Object* object) {
   }
 }
 
-VM* freeVM(VM *vm) {
-  while(vm->stackSize >0) pop(vm);
+void freeVM(VM *vm) {
+  vm->stackSize = 0;
   gc(vm);
   free(vm);
 }


### PR DESCRIPTION
Added freeVM(), which fixes memory leak.

Added Makefile for convenience of building executable and testing for leaks. To run the test, simply type
make run
