### PR TITLE
Fix valgrind run path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,5 @@ clean :
 	rm -f $(BIN) *~
 
 run : $(BIN)
-	valgrind  --leak-check=yes $(BIN)
+	valgrind  --leak-check=yes ./$(BIN)
 


### PR DESCRIPTION
In my ubuntu machine, the valgrind need to be run with executable path (./$(BIN)) so I fix it to build and run for the whole project.