### PR TITLE
Reset vm->maxObjects to init value when vm->numObjects equals to zero

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #define STACK_MAX 256
+#define INIT_OBJ_NUM_MAX 8
 
 typedef enum {
   OBJ_INT,
@@ -53,7 +54,7 @@ VM* newVM() {
   vm->stackSize = 0;
   vm->firstObject = NULL;
   vm->numObjects = 0;
-  vm->maxObjects = 8;
+  vm->maxObjects = INIT_OBJ_NUM_MAX;
   return vm;
 }
 
@@ -116,7 +117,7 @@ void gc(VM* vm) {
   markAll(vm);
   sweep(vm);
 
-  vm->maxObjects = vm->numObjects * 2;
+  vm->maxObjects = vm->numObjects == 0 ? INIT_OBJ_NUM_MAX : vm->numObjects * 2;
 
   printf("Collected %d objects, %d remaining.\n", numObjects - vm->numObjects,
          vm->numObjects);


### PR DESCRIPTION
When vm->numObjects equals to zero, it won't trigger gc any more.